### PR TITLE
Added support for using more different symbols

### DIFF
--- a/app/docs.md
+++ b/app/docs.md
@@ -1,7 +1,14 @@
 # SymbolicEqual
 Evaluates the equality between two symbolic expressions using the python [`SymPy`](https://docs.sympy.org/latest/index.html) package. 
 
+Note that `pi` is a reserved constant and cannot be used as a symbol name.
+
 ## Inputs
+
+### Optional grading parameters
+If you want to use `I` for the imaginary constant, set the grading parameter `complexNumbers` to True.
+
+If you want to use the special functions `beta` (Euler Beta function), `gamma` (Gamma function) and `zeta` (Riemann Zeta function), set the grading parameter `specialFunctions` to True.
 
 ## Outputs
 Outputs to the `eval` command will feature:

--- a/app/evaluation.py
+++ b/app/evaluation.py
@@ -20,19 +20,37 @@ def evaluation_function(response, answer, params) -> dict:
     """
 
     from sympy.parsing.sympy_parser import parse_expr
-    from sympy import expand, simplify, trigsimp, latex
+    from sympy import expand, simplify, trigsimp, latex, Symbol
+    from sympy import pi
+
+    if params.get("specialFunctions",False) == True:
+        from sympy import beta, gamma, zeta
+    else:
+        beta = Symbol("beta")
+        gamma = Symbol("gamma")
+        zeta = Symbol("zeta")
+    if params.get("complexNumbers",False) == True:
+        from sympy import I
+    else:
+        I = Symbol("I")
+    E = Symbol("E")
+    N = Symbol("N")
+    O = Symbol("O")
+    Q = Symbol("Q")
+    S = Symbol("S")
+    symbol_dict = {"beta": beta,"gamma": gamma, "zeta": zeta, "I": I, "N": N, "O": O, "Q": Q, "S": S, "E": E}
 
     # Dealing with special cases that aren't accepted by SymPy
     response, answer = Absolute(response, answer)
 
     # Safely try to parse answer and response into symbolic expressions
     try:
-        res = parse_expr(response)
+        res = parse_expr(response, local_dict = symbol_dict)
     except (SyntaxError, TypeError) as e:
         raise Exception("SymPy was unable to parse the response") from e
 
     try:
-        ans = parse_expr(answer)
+        ans = parse_expr(answer, local_dict = symbol_dict)
     except (SyntaxError, TypeError) as e:
         raise Exception("SymPy was unable to parse the answer") from e
 

--- a/app/evaluation_tests.py
+++ b/app/evaluation_tests.py
@@ -107,6 +107,41 @@ class TestEvaluationFunction(unittest.TestCase):
 
         self.assertEqual(cm.exception.args[1] == "tooMany|InAnswer", True)
 
+    def test_clashing_symbols(self):
+        params = {}
+        response = "beta+gamma+zeta+I+N+O+Q+S+E"
+        answer = "E+S+Q+O+N+I+zeta+gamma+beta"
+        result = evaluation_function(response, answer, params)
+        self.assertEqual(result.get("is_correct"), True)
+
+    def test_special_constants(self):
+        response = "pi"
+        answer = "2*asin(1)"
+        params = {}
+        result = evaluation_function(response, answer, params)
+        self.assertEqual(result.get("is_correct"), True)
+
+    def test_complex_numbers(self):
+        response = "I"
+        answer = "(-1)**(1/2)"
+        params = {"complexNumbers": True}
+        result = evaluation_function(response, answer, params)
+        self.assertEqual(result.get("is_correct"), True)
+
+    def test_special_functions(self):
+        params = {"specialFunctions": True}
+        response = "beta(1,x)"
+        answer = "1/x"
+        result = evaluation_function(response, answer, params)
+        self.assertEqual(result.get("is_correct"), True)
+        response = "gamma(5)"
+        answer = "4*3*2"
+        result = evaluation_function(response, answer, params)
+        self.assertEqual(result.get("is_correct"), True)
+        response = "zeta(2)"
+        answer = "pi**2/6"
+        result = evaluation_function(response, answer, params)
+        self.assertEqual(result.get("is_correct"), True)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The following symbols (that previously clashed with some other meaning in sympy) can now be used as variable names:
beta, gamma, zeta, I, N, O, Q, S, E
Note that pi is still reserved.
If you want to use I for the imaginary constant, set the grading parameter "complexNumbers" to True.
If you want to use the special functions (Euler Beta function, Gamma function, Riemann Zeta function), set the grading parameter "specialFunctions" to True.